### PR TITLE
Fix shebang

### DIFF
--- a/gerrit-report.py
+++ b/gerrit-report.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import argparse
 import subprocess


### PR DESCRIPTION
In most environment, /usr/bin/env is used instead of /bin/env, e.g. on
Ubuntu execute the script gives "bad interpreter" error.
Fix the issue by using /usr/bin/env as shebang.