### PR TITLE
Ignore stderr of ssh output

### DIFF
--- a/gerrit-report.py
+++ b/gerrit-report.py
@@ -15,7 +15,7 @@ def query(*args):
     s = subprocess.getoutput("ssh openbmc.gerrit gerrit query " +
                              "--format json --all-reviewers " +
                              "--dependencies --current-patch-set -- '" +
-                             " ".join(args) + "'")
+                             " ".join(args) + "'" + " 2>/dev/null")
     results = list(map(json.loads, s.splitlines()))
     del results[-1]
 


### PR DESCRIPTION
Ignore ssh output's stderr and only capture stdout.
Otherwise stderr's output is parsed as results and cause error.

Typically if user has `ForwardX11 yes` in ~/.ssh/config, ssh will output
"No xauth data" to stderr.